### PR TITLE
Add support for UNIX-style non-zero padded notation

### DIFF
--- a/arrow.go
+++ b/arrow.go
@@ -287,15 +287,22 @@ func formatConvert(format string) string {
 // Parse the time using the same format string types as strftime
 // See http://man7.org/linux/man-pages/man3/strftime.3.html for more info.
 func CParse(layout, value string) (Arrow, error) {
-	t, e := time.Parse(formatConvert(layout), value)
-	return New(t), e
+	return CParseInLocation(layout, value, nil)
 }
 
 // Parse the time using the same format string types as strftime,
 // within the given location.
 // See http://man7.org/linux/man-pages/man3/strftime.3.html for more info.
 func CParseInLocation(layout, value string, loc *time.Location) (Arrow, error) {
-	t, e := time.ParseInLocation(formatConvert(layout), value, loc)
+	parseFunc := func(layout string, value string, loc *time.Location) (time.Time, error) {
+		if loc == nil {
+			return time.Parse(layout, value)
+		} else {
+			return time.ParseInLocation(layout, value, loc)
+		}
+	}
+	layout = strings.Replace(layout, "%-H", "%H", -1)
+	t, e := parseFunc(formatConvert(layout), value, loc)
 	return New(t), e
 }
 

--- a/arrow.go
+++ b/arrow.go
@@ -225,50 +225,56 @@ func (a Arrow) AddDurations(durations ...string) Arrow {
 func formatConvert(format string) string {
 	// create mapping from strftime to time in Go
 	strftimeMapping := map[string]string{
-		"%a": "Mon",
-		"%A": "Monday",
-		"%b": "Jan",
-		"%B": "January",
-		"%c": "", // locale not supported
-		"%C": "06",
-		"%d": "02",
-		"%D": "01/02/06",
-		"%e": "_2",
-		"%E": "", // modifiers not supported
-		"%F": "2006-01-02",
-		"%G": "%G", // special case, see below
-		"%g": "%g", // special case, see below
-		"%h": "Jan",
-		"%H": "15",
-		"%I": "03",
-		"%j": "%j", // special case, see below
-		"%k": "%k", // special case, see below
-		"%l": "_3",
-		"%m": "01",
-		"%M": "04",
-		"%n": "\n",
-		"%O": "", // modifiers not supported
-		"%p": "PM",
-		"%P": "pm",
-		"%r": "03:04:05 PM",
-		"%R": "15:04",
-		"%s": "%s", // special case, see below
-		"%S": "05",
-		"%t": "\t",
-		"%T": "15:04:05",
-		"%u": "%u", // special case, see below
-		"%U": "%U", // special case, see below
-		"%V": "%V", // special case, see below
-		"%w": "%w", // special case, see below
-		"%W": "%W", // special case, see below
-		"%x": "%x", // locale not supported
-		"%X": "%X", // locale not supported
-		"%y": "06",
-		"%Y": "2006",
-		"%z": "-0700",
-		"%Z": "MST",
-		"%+": "Mon Jan _2 15:04:05 MST 2006",
-		"%%": "%%", // special case, see below
+		"%a":  "Mon",
+		"%A":  "Monday",
+		"%b":  "Jan",
+		"%B":  "January",
+		"%c":  "", // locale not supported
+		"%C":  "06",
+		"%d":  "02",
+		"%-d": "2",
+		"%D":  "01/02/06",
+		"%e":  "_2",
+		"%E":  "", // modifiers not supported
+		"%F":  "2006-01-02",
+		"%G":  "%G", // special case, see below
+		"%g":  "%g", // special case, see below
+		"%h":  "Jan",
+		"%H":  "15",  // this actually means the hour can never be formatted as non-zero padded...
+		"%-H": "%-H", // special case, see below
+		"%I":  "03",
+		"%-I": "3",
+		"%j":  "%j", // special case, see below
+		"%k":  "%k", // special case, see below
+		"%l":  "_3",
+		"%m":  "01",
+		"%-m": "1",
+		"%M":  "04",
+		"%-M": "4",
+		"%n":  "\n",
+		"%O":  "", // modifiers not supported
+		"%p":  "PM",
+		"%P":  "pm",
+		"%r":  "03:04:05 PM",
+		"%R":  "15:04",
+		"%s":  "%s", // special case, see below
+		"%S":  "05",
+		"%-S": "5",
+		"%t":  "\t",
+		"%T":  "15:04:05",
+		"%u":  "%u", // special case, see below
+		"%U":  "%U", // special case, see below
+		"%V":  "%V", // special case, see below
+		"%w":  "%w", // special case, see below
+		"%W":  "%W", // special case, see below
+		"%x":  "%x", // locale not supported
+		"%X":  "%X", // locale not supported
+		"%y":  "06",
+		"%Y":  "2006",
+		"%z":  "-0700",
+		"%Z":  "MST",
+		"%+":  "Mon Jan _2 15:04:05 MST 2006",
+		"%%":  "%%", // special case, see below
 	}
 
 	for fmt, conv := range strftimeMapping {
@@ -335,6 +341,7 @@ func (a Arrow) CFormat(format string) string {
 		format = strings.Replace(format, "%u", sweekday, -1)
 	}
 
+	format = strings.Replace(format, "%-H", strconv.Itoa(a.Hour()), -1)
 	format = strings.Replace(format, "%U", weekNumber(a, time.Sunday), -1)
 	format = strings.Replace(format, "%U", sweek, -1)
 	format = strings.Replace(format, "%w", sweekday, -1)

--- a/arrow.go
+++ b/arrow.go
@@ -240,7 +240,7 @@ func formatConvert(format string) string {
 		"%G":  "%G", // special case, see below
 		"%g":  "%g", // special case, see below
 		"%h":  "Jan",
-		"%H":  "15",  // this actually means the hour can never be formatted as non-zero padded...
+		"%H":  "15",
 		"%-H": "%-H", // special case, see below
 		"%I":  "03",
 		"%-I": "3",

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -12,3 +12,49 @@ func TestCParse(t *testing.T) {
 		t.Error("CParseInLocation")
 	}
 }
+
+func TestCFormat(t *testing.T) {
+	tests := []struct {
+		datetime time.Time
+		format   string
+		expected string
+	}{
+		{
+			datetime: time.Date(1980, time.June, 19, 0, 0, 0, 0, time.UTC),
+			format:   "%Y-%m-%d",
+			expected: "1980-06-19",
+		},
+		{
+			datetime: time.Date(2022, time.January, 8, 0, 0, 0, 0, time.UTC),
+			format:   "%Y-%-m-%-d",
+			expected: "2022-1-8",
+		},
+		{
+			datetime: time.Date(2022, time.January, 8, 21, 2, 0, 0, time.UTC),
+			format:   "%Y-%-m-%-d %-I:%-M",
+			expected: "2022-1-8 9:2",
+		},
+		{
+			datetime: time.Date(2022, time.January, 8, 4, 2, 0, 0, time.UTC),
+			format:   "%Y-%-m-%-d %-H:%-M",
+			expected: "2022-1-8 4:2",
+		},
+		{
+			datetime: time.Date(2022, time.January, 8, 13, 2, 0, 0, time.UTC),
+			format:   "%Y-%-m-%-d %-H:%-M",
+			expected: "2022-1-8 13:2",
+		},
+		{
+			datetime: time.Date(2006, time.August, 9, 23, 59, 11, 0, time.UTC),
+			format:   "%Y-%-m-%-dT%H:%M:%S",
+			expected: "2006-8-9T23:59:11",
+		},
+	}
+	for _, test := range tests {
+		a := New(test.datetime)
+		actual := a.CFormat(test.format)
+		if actual != test.expected {
+			t.Errorf("CFormat(%s) returned %s, expected %s", test.format, actual, test.expected)
+		}
+	}
+}

--- a/arrow_test.go
+++ b/arrow_test.go
@@ -5,11 +5,73 @@ import (
 	"time"
 )
 
+func loadLocation(name string) *time.Location {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return nil
+	}
+	return loc
+}
+
 func TestCParse(t *testing.T) {
-	loc, _ := time.LoadLocation("America/New_York")
-	a, _ := CParseInLocation("%Y-%m-%d", "1980-06-19", loc)
-	if a.Format("2006-01-02") != "1980-06-19" {
-		t.Error("CParseInLocation")
+	tests := []struct {
+		dateStr  string
+		timezone string
+		format   string
+		expected time.Time
+	}{
+		{
+			dateStr:  "1980-06-19",
+			timezone: "America/New_York",
+			format:   "%Y-%m-%d",
+			expected: time.Date(1980, time.June, 19, 0, 0, 0, 0, loadLocation("America/New_York")),
+		},
+		{
+			dateStr:  "1980-6-19",
+			timezone: "America/New_York",
+			format:   "%Y-%-m-%d",
+			expected: time.Date(1980, time.June, 19, 0, 0, 0, 0, loadLocation("America/New_York")),
+		},
+		{
+			dateStr:  "1980-6-19 9:02",
+			timezone: "America/New_York",
+			format:   "%Y-%-m-%d %-I:%M",
+			expected: time.Date(1980, time.June, 19, 9, 2, 0, 0, loadLocation("America/New_York")),
+		},
+		{
+			dateStr:  "1980-6-19 9:02",
+			timezone: "America/New_York",
+			format:   "%Y-%-m-%d %-H:%M",
+			expected: time.Date(1980, time.June, 19, 9, 2, 0, 0, loadLocation("America/New_York")),
+		},
+		{
+			dateStr:  "1980-6-19 09:02",
+			timezone: "America/New_York",
+			format:   "%Y-%-m-%d %-H:%M",
+			expected: time.Date(1980, time.June, 19, 9, 2, 0, 0, loadLocation("America/New_York")),
+		},
+		{
+			dateStr:  "1980-6-19 9:02",
+			timezone: "America/New_York",
+			format:   "%Y-%-m-%d %H:%M",
+			expected: time.Date(1980, time.June, 19, 9, 2, 0, 0, loadLocation("America/New_York")),
+		},
+		{
+			dateStr:  "1980-6-0109:02",
+			timezone: "America/New_York",
+			format:   "%Y-%-m-%d%H:%M",
+			expected: time.Date(1980, time.June, 1, 9, 2, 0, 0, loadLocation("America/New_York")),
+		},
+	}
+	for _, test := range tests {
+		loc, _ := time.LoadLocation(test.timezone)
+		actual, err := CParseInLocation(test.format, test.dateStr, loc)
+		if err != nil {
+			t.Errorf("Error parsing date: %s", err)
+		}
+		if !actual.Time.Equal(test.expected) {
+			t.Errorf("CParseInLocation(%s, %s, %s): Expected %s, got %s", test.format, test.dateStr, test.timezone, test.expected, actual)
+		}
 	}
 }
 


### PR DESCRIPTION
Many operating systems support non-zero padded time component formatting (e.g. `3:5` vs. `03:05`).
On UNIX, the notation used is a dash separating the `%` and the time component character (e.g. `%-H` for non-zero padded 24-h hour).
Said notation is supported in many formatting libraries in other languages.